### PR TITLE
fix: scope injected Tailwind CSS var reset to library elements

### DIFF
--- a/library/convert-tailwind-to-css.js
+++ b/library/convert-tailwind-to-css.js
@@ -33,9 +33,10 @@ postcss([
       formattedCSS = formattedCSS.replace(classRegex, '');
     });
 
-    //Init all tailwind vars
+    //Init all tailwind vars on the library's own elements only, so the
+    //reset cannot override the host app's Tailwind utilities (see #34)
     formattedCSS = `${formattedCSS} 
-*, ::before, ::after {
+[class*="vot-"], [class*="vot-"]::before, [class*="vot-"]::after {
   --tw-border-spacing-x: 0;
   --tw-border-spacing-y: 0;
   --tw-translate-x: 0;

--- a/library/src/assets/index.css
+++ b/library/src/assets/index.css
@@ -166,7 +166,7 @@
   --tw-text-opacity: 1;
   color: rgb(30 64 175 / var(--tw-text-opacity, 1));
 } 
-*, ::before, ::after {
+[class*="vot-"], [class*="vot-"]::before, [class*="vot-"]::after {
   --tw-border-spacing-x: 0;
   --tw-border-spacing-y: 0;
   --tw-translate-x: 0;


### PR DESCRIPTION
Fixes #34

## Problem

The library's generated stylesheet (injected into the host app's `<head>` by `vite-plugin-css-injected-by-js` when the module is imported) ends with an **unscoped universal rule** that initializes Tailwind's internal custom properties:

```css
*, ::before, ::after {
  --tw-translate-x: 0;
  ...
  --tw-shadow: 0 0 #0000;
  --tw-backdrop-blur: ;
  ...
}
```

This rule is appended by `convert-tailwind-to-css.js` ("Init all tailwind vars").

Host apps built with **Tailwind CSS v4** put their utilities in `@layer utilities`. Since unlayered declarations always take precedence over layered ones in the CSS cascade (regardless of specificity), this universal rule silently overrides the host app's own `--tw-*` variables on **every element of the page**. Depending on which utilities the host app uses, this breaks:

- `translate-x-*` / `translate-y-*` (e.g. centered modals — the exact symptom in #34)
- `shadow-*` (collapses to `0 0 #0000`)
- `backdrop-blur-*` and other filters (collapse to `none` — how we hit it: frosted-glass cards going fully transparent as soon as the page chunk importing the tour loaded)
- gradient position utilities, ring utilities, etc.

## Fix

Scope the variable-init rule to the library's own elements. All generated utilities use the `vot-` prefix, so every element that consumes these variables carries a `vot-*` class:

```css
[class*="vot-"], [class*="vot-"]::before, [class*="vot-"]::after { ... }
```

Applied in `convert-tailwind-to-css.js` (source of the block) and regenerated in `src/assets/index.css`. The tour's own styling is unaffected — the defaults still apply to every `vot-*` element — but the reset can no longer leak into host applications.

## Verification

Reproduced the breakage in a Tailwind v4 + Nuxt app (backdrop-filter computed value flips from `blur(24px)` to `none` the moment the library's stylesheet is injected). With the scoped rule, host-app utilities are untouched and the tour renders identically.
